### PR TITLE
Install `rsync`, so that rsync shared folders work

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -7,5 +7,8 @@ echo "export PKG_PATH=\"$PKG_PATH\"" >> /home/vagrant/.profile
 # install wget/curl
 pkg_add wget curl
 
+#install the normal flavour of `rsync`
+pkg_add -v rsync--
+
 # sudo
 echo "vagrant ALL=(ALL) NOPASSWD: SETENV: ALL" >> /etc/sudoers


### PR DESCRIPTION
Otherwise `vagrant up` fails:

```
$ vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'tmatilai/openbsd-5.5'...
==> default: Matching MAC address for NAT networking...
==> default: Checking if box 'tmatilai/openbsd-5.5' is up to date...
==> default: Setting the name of the VM: openbsd_default_1407488719773_56668
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
==> default: Forwarding ports...
    default: 22 => 2222 (adapter 1)
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: Warning: Connection timeout. Retrying...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
    default: No guest additions were detected on the base box for this VM! Guest
    default: additions are required for forwarded ports, shared folders, host only
    default: networking, and more. If SSH fails on this machine, please install
    default: the guest additions and repackage the box to continue.
    default: 
    default: This is not an error message; everything may continue to work properly,
    default: in which case you may ignore this message.
==> default: Setting hostname...
==> default: Installing rsync to the VM...
==> default: Rsyncing folder: /var/tmp/syv/src/openbsd/ => /vagrant
There was an error when attempting to rsync a synced folder.
Please inspect the error message below for more info.

Host path: /var/tmp/syv/src/openbsd/
Guest path: /vagrant
Command: rsync --verbose --archive --delete -z --copy-links --no-owner --no-group --rsync-path sudo rsync -e ssh -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i '/home/systems/syv/.vagrant.d/insecure_private_key' --exclude .vagrant/ /var/tmp/syv/src/openbsd/ vagrant@127.0.0.1:/vagrant
Error: Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
X11 forwarding request failed on channel 0
sudo: rsync: command not found
rsync: connection unexpectedly closed (0 bytes received so far) [sender]
rsync error: error in rsync protocol data stream (code 12) at io.c(235) [sender=3.1.0]

$ 
```

There's no `rsync` in the OpenBSD box:

```
$ vagrant ssh
OpenBSD 5.5 (GENERIC) #271: Wed Mar  5 09:31:16 MST 2014

Welcome to OpenBSD: The proactively secure Unix-like operating system.

Please use the sendbug(1) utility to report bugs in the system.
Before reporting a bug, please try to reproduce it with the latest
version of the code.  With bug reports, please try to ensure that
enough information to reproduce the problem is enclosed, and if a
known fix for it exists, include that as well.

$ which rsync
which: rsync: Command not found.
$
```
