### PR TITLE
Add OpenBSD 5.8 templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# _Not released yet_
+
+## OpenBSD 5.8 - 1.0.0
+
+- Add templates for OpenBSD 5.8 (@dentarg)
+
 # 2015-10-02
 
 ## OpenBSD 5.7 - 1.0.2

--- a/openbsd-5.8-amd64.json
+++ b/openbsd-5.8-amd64.json
@@ -1,0 +1,146 @@
+{
+  "variables": {
+    "chef_version": "provisionerless",
+    "ftp_proxy": "{{env `ftp_proxy`}}",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "mirror": "http://ftp.openbsd.org",
+    "vagrant_ansible": "no",
+    "atlas_box_name": "tmatilai/openbsd-5.8",
+    "atlas_box_version": "1.0.0"
+  },
+  "provisioners": [
+    {
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}",
+        "MIRROR={{user `mirror`}}",
+        "ftp_proxy={{user `ftp_proxy`}}",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "VAGRANT_ANSIBLE={{user `vagrant_ansible`}}"
+      ],
+      "type": "shell",
+      "scripts": [
+        "scripts-5.8/postinstall.sh",
+        "scripts-5.8/ansible.sh",
+        "scripts/chef.sh",
+        "scripts/minimize.sh"
+      ],
+      "execute_command": "export {{.Vars}} && cat {{.Path}} | su -m"
+    }
+  ],
+  "builders": [
+    {
+      "type": "virtualbox-iso",
+      "boot_command": [
+        "S<enter>",
+        "cat <<EOF >>install.conf<enter>",
+        "System hostname = openbsd58<enter>",
+        "Password for root = vagrant<enter>",
+        "Allow root ssh login = yes<enter>",
+        "What timezone are you in = UTC<enter>",
+        "Location of sets = cd<enter>",
+        "Set name(s) = -game*.tgz -x*.tgz<enter>",
+        "Directory does not contain SHA256.sig. Continue without verification = yes<enter>",
+        "EOF<enter>",
+        "install -af install.conf && reboot<enter>"
+      ],
+      "boot_wait": "30s",
+      "disk_size": 10140,
+      "guest_additions_mode": "disable",
+      "guest_os_type": "OpenBSD_64",
+      "iso_checksum": "2edd369c4b5f1960f9c974ee7f7bbe4105137968c1542d37411e83cb79f7f6f2",
+      "iso_checksum_type": "sha256",
+      "iso_url": "{{user `mirror`}}/pub/OpenBSD/5.8/amd64/install58.iso",
+      "output_directory": "packer-openbsd-5.8-amd64-virtualbox",
+      "shutdown_command": "/sbin/halt -p",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
+        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "openbsd-5.8-amd64"
+    },
+    {
+      "type": "vmware-iso",
+      "boot_command": [
+        "S<enter>",
+        "cat <<EOF >>install.conf<enter>",
+        "System hostname = openbsd58<enter>",
+        "Password for root = vagrant<enter>",
+        "Allow root ssh login = yes<enter>",
+        "What timezone are you in = UTC<enter>",
+        "Location of sets = cd<enter>",
+        "Set name(s) = -game*.tgz -x*.tgz<enter>",
+        "Directory does not contain SHA256.sig. Continue without verification = yes<enter>",
+        "EOF<enter>",
+        "install -af install.conf && reboot<enter>"
+      ],
+      "boot_wait": "30s",
+      "disk_size": 10140,
+      "guest_os_type": "other-64",
+      "iso_checksum": "2edd369c4b5f1960f9c974ee7f7bbe4105137968c1542d37411e83cb79f7f6f2",
+      "iso_checksum_type": "sha256",
+      "iso_url": "{{user `mirror`}}/pub/OpenBSD/5.8/amd64/install58.iso",
+      "output_directory": "packer-openbsd-5.8-amd64-vmware",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -p",
+      "vm_name": "openbsd-5.8-amd64",
+      "vmx_data": {
+        "memsize": "384",
+        "numvcpus": "1",
+        "cpuid.coresPerSocket": "1"
+      }
+    },
+    {
+      "type": "qemu",
+      "boot_command": [
+        "S<enter>",
+        "cat <<EOF >>install.conf<enter>",
+        "System hostname = openbsd58<enter>",
+        "Password for root = vagrant<enter>",
+        "Allow root ssh login = yes<enter>",
+        "What timezone are you in = UTC<enter>",
+        "Location of sets = cd<enter>",
+        "Set name(s) = -game*.tgz -x*.tgz<enter>",
+        "Directory does not contain SHA256.sig. Continue without verification = yes<enter>",
+        "EOF<enter>",
+        "install -af install.conf && reboot<enter>"
+      ],
+      "boot_wait": "30s",
+      "disk_size": 10140,
+      "iso_checksum": "3f714d249a6dc8f40c2fc2fccea8ef9987e74a2b81483175d081661c3533b59a",
+      "iso_checksum_type": "sha256",
+      "iso_url": "{{user `mirror`}}/pub/OpenBSD/5.8/amd64/install58.iso",
+      "output_directory": "packer-openbsd-5.8-amd64-qemu",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -p",
+      "vm_name": "openbsd-5.8-amd64",
+      "qemuargs": [
+        [ "-m", "384M" ],
+        [ "-smp", "cores=1,threads=1,sockets=1" ]
+      ]
+    }
+  ],
+  "post-processors": [
+    [{
+      "type": "vagrant",
+      "output": "openbsd-5.8-amd64-{{.Provider}}.box",
+      "vagrantfile_template": "vagrantfiles/openbsd"
+    }]
+  ],
+  "push": {
+    "name": "",
+    "vcs": true
+  }
+}

--- a/openbsd-5.8-i386.json
+++ b/openbsd-5.8-i386.json
@@ -1,0 +1,140 @@
+{
+  "variables": {
+    "chef_version": "provisionerless",
+    "ftp_proxy": "{{env `ftp_proxy`}}",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "mirror": "http://ftp.openbsd.org",
+    "vagrant_ansible": "no"
+  },
+  "provisioners": [
+    {
+      "environment_vars": [
+        "CHEF_VERSION={{user `chef_version`}}",
+        "MIRROR={{user `mirror`}}",
+        "ftp_proxy={{user `ftp_proxy`}}",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "VAGRANT_ANSIBLE={{user `vagrant_ansible`}}"
+      ],
+      "type": "shell",
+      "scripts": [
+        "scripts/postinstall.sh",
+        "scripts/ansible.sh",
+        "scripts/chef.sh",
+        "scripts/minimize.sh"
+      ],
+      "execute_command": "export {{.Vars}} && cat {{.Path}} | su -m"
+    }
+  ],
+  "builders": [
+    {
+      "type": "virtualbox-iso",
+      "boot_command": [
+        "S<enter>",
+        "cat <<EOF >>install.conf<enter>",
+        "System hostname = openbsd58<enter>",
+        "Password for root = vagrant<enter>",
+        "Allow root ssh login = yes<enter>",
+        "What timezone are you in = UTC<enter>",
+        "Location of sets = cd<enter>",
+        "Set name(s) = -game*.tgz -x*.tgz<enter>",
+        "Directory does not contain SHA256.sig. Continue without verification = yes<enter>",
+        "EOF<enter>",
+        "install -af install.conf && reboot<enter>"
+      ],
+      "boot_wait": "30s",
+      "disk_size": 10140,
+      "guest_additions_mode": "disable",
+      "guest_os_type": "OpenBSD",
+      "iso_checksum": "5412bb5ecbf4593e1319170a66ec7d02254394496a385883501e16540a638972",
+      "iso_checksum_type": "sha256",
+      "iso_url": "{{user `mirror`}}/pub/OpenBSD/5.8/i386/install58.iso",
+      "output_directory": "packer-openbsd-5.8-i386-virtualbox",
+      "shutdown_command": "/sbin/halt -p",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "vboxmanage": [
+        [ "modifyvm", "{{.Name}}", "--memory", "384" ],
+        [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
+      ],
+      "virtualbox_version_file": ".vbox_version",
+      "vm_name": "openbsd-5.8-i386"
+    },
+    {
+      "type": "vmware-iso",
+      "boot_command": [
+        "S<enter>",
+        "cat <<EOF >>install.conf<enter>",
+        "System hostname = openbsd58<enter>",
+        "Password for root = vagrant<enter>",
+        "Allow root ssh login = yes<enter>",
+        "What timezone are you in = UTC<enter>",
+        "Location of sets = cd<enter>",
+        "Set name(s) = -game*.tgz -x*.tgz<enter>",
+        "Directory does not contain SHA256.sig. Continue without verification = yes<enter>",
+        "EOF<enter>",
+        "install -af install.conf && reboot<enter>"
+      ],
+      "boot_wait": "30s",
+      "disk_size": 10140,
+      "guest_os_type": "other",
+      "iso_checksum": "5412bb5ecbf4593e1319170a66ec7d02254394496a385883501e16540a638972",
+      "iso_checksum_type": "sha256",
+      "iso_url": "{{user `mirror`}}/pub/OpenBSD/5.8/i386/install58.iso",
+      "output_directory": "packer-openbsd-5.8-i386-vmware",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -p",
+      "vm_name": "openbsd-5.8-i386",
+      "vmx_data": {
+        "memsize": "384",
+        "numvcpus": "1",
+        "cpuid.coresPerSocket": "1"
+      }
+    },
+    {
+      "type": "qemu",
+      "boot_command": [
+        "S<enter>",
+        "cat <<EOF >>install.conf<enter>",
+        "System hostname = openbsd58<enter>",
+        "Password for root = vagrant<enter>",
+        "Allow root ssh login = yes<enter>",
+        "What timezone are you in = UTC<enter>",
+        "Location of sets = cd<enter>",
+        "Set name(s) = -game*.tgz -x*.tgz<enter>",
+        "Directory does not contain SHA256.sig. Continue without verification = yes<enter>",
+        "EOF<enter>",
+        "install -af install.conf && reboot<enter>"
+      ],
+      "boot_wait": "30s",
+      "disk_size": 10140,
+      "iso_checksum": "5412bb5ecbf4593e1319170a66ec7d02254394496a385883501e16540a638972",
+      "iso_checksum_type": "sha256",
+      "iso_url": "{{user `mirror`}}/pub/OpenBSD/5.8/i386/install58.iso",
+      "output_directory": "packer-openbsd-5.8-i386-qemu",
+      "ssh_username": "root",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "/sbin/halt -p",
+      "vm_name": "openbsd-5.8-i386",
+      "qemuargs": [
+        [ "-m", "384M" ],
+        [ "-smp", "cores=1,threads=1,sockets=1" ]
+      ]
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "output": "openbsd-5.8-i386-{{.Provider}}.box",
+      "vagrantfile_template": "vagrantfiles/openbsd"
+    }
+  ]
+}

--- a/scripts-5.8/ansible.sh
+++ b/scripts-5.8/ansible.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+
+if [ x$VAGRANT_ANSIBLE = x'yes' ]; then
+	. /root/.profile
+
+	uname_r=`uname -r`
+	if [ $uname_r = 5.8 ]; then
+		pkg_add python-2.7.10
+	elif [ $uname_r = 5.7 ]; then
+		pkg_add python-2.7.9
+	elif [ $uname_r = 5.6 ]; then
+		pkg_add python-2.7.8
+	elif [ $uname_r = 5.5 ]; then
+		pkg_add python-2.7.6p0
+	elif [ $uname_r = 5.4 ]; then
+		pkg_add python-2.7.5
+	else
+		echo "Did not recognise OpenBSD version."
+		exit 1
+	fi
+else
+	echo "Building a box without Python 2 (Ansible)"
+fi

--- a/scripts-5.8/postinstall.sh
+++ b/scripts-5.8/postinstall.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -e
+
+export PKG_PATH="$MIRROR/pub/OpenBSD/`uname -r`/packages/`arch -s`/"
+
+# create vagrant user/group and home directory
+groupadd vagrant
+adduser -noconfig -unencrypted -batch vagrant vagrant,wheel vagrant vagrant
+
+# set pkg path for users
+echo "export PKG_PATH=\"$PKG_PATH\"" >> /root/.profile
+echo "export PKG_PATH=\"$PKG_PATH\"" >> /home/vagrant/.profile
+
+# install wget/curl/sudo
+pkg_add wget curl sudo--
+
+# sudo
+echo "vagrant ALL=(ALL) NOPASSWD: SETENV: ALL" >> /etc/sudoers
+
+# add vagrant pub key
+wget --no-check-certificate \
+    'https://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' \
+    -O /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh
+chmod -R go-rwsx /home/vagrant/.ssh


### PR DESCRIPTION
I had to create `scripts-5.8/` to not break the older templates.

I left out the "atlas" definitions from "post-processors" because packer wont even build or validate when you don't have an `ATLAS_TOKEN` in your env.

I think this repo would benefit from a change of strategy: instead of creating new files for each release, we could take advantage of the fact that we are using git use branches or tags :-)

It would be much easier to follow changes, and we don't have to worry about backward and forward compatibility.