### PR TITLE
Fix checksum for qemu 5.8 ISO

### DIFF
--- a/openbsd-5.8-amd64.json
+++ b/openbsd-5.8-amd64.json
@@ -123,7 +123,7 @@
       ],
       "boot_wait": "30s",
       "disk_size": 10140,
-      "iso_checksum": "3f714d249a6dc8f40c2fc2fccea8ef9987e74a2b81483175d081661c3533b59a",
+      "iso_checksum": "2edd369c4b5f1960f9c974ee7f7bbe4105137968c1542d37411e83cb79f7f6f2",
       "iso_checksum_type": "sha256",
       "iso_url": "{{user `mirror`}}/pub/OpenBSD/5.8/amd64/install58.iso",
       "output_directory": "packer-openbsd-5.8-amd64-qemu",


### PR DESCRIPTION
Put correct ISO-checksum for qemu-build.